### PR TITLE
Corrected error on DirectionsWaypoint

### DIFF
--- a/GMapsFX/src/main/java/com/lynden/gmapsfx/service/directions/DirectionsWaypoint.java
+++ b/GMapsFX/src/main/java/com/lynden/gmapsfx/service/directions/DirectionsWaypoint.java
@@ -38,7 +38,7 @@ public class DirectionsWaypoint extends JavascriptObject{
     }
     
     public DirectionsWaypoint(LatLong l){
-        super(GMapObjectType.DIRECTIONS_WAYPOINT, "{location: " + l + "}");
+        super(GMapObjectType.DIRECTIONS_WAYPOINT, "{location: " + l.getVariableName() + "}");
         //getJSObject().setMember("location", l);
     }
     


### PR DESCRIPTION
When passing LatLong as an argument to the DirectionsWaypoint constructor it creates a wrong javascript string:

"{location: " + l.toString() + "}" -> {location: lat: 1.000000 lng: 1.0000000}

 I changed it so it just passes the LatLong variable name.